### PR TITLE
Fix code scanning alert for hard-coded credentials in mocks

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,2 @@
+LANGCHAIN_API_KEY=test-api-key
+LANGGRAPH_API_URL=https://api.example.com

--- a/__tests__/api/proxy.test.ts
+++ b/__tests__/api/proxy.test.ts
@@ -1,14 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { GET, POST, PUT, PATCH, DELETE, OPTIONS } from '@/app/api/[..._path]/route';
+import dotenv from 'dotenv';
 
-// Mock environment variables
-const MOCK_API_KEY = 'test-api-key';
-const MOCK_API_URL = 'https://api.example.com';
+// Load environment variables from .env.test file
+dotenv.config({ path: '.env.test' });
 
 beforeEach(() => {
-    process.env.LANGCHAIN_API_KEY = MOCK_API_KEY;
-    process.env.LANGGRAPH_API_URL = MOCK_API_URL;
-
     // Reset fetch mock
     global.fetch = jest.fn();
 });
@@ -49,11 +46,11 @@ describe('API Route Handler', () => {
             await GET(req);
 
             expect(global.fetch).toHaveBeenCalledWith(
-                `${MOCK_API_URL}/test?param=value`,
+                `${process.env.LANGGRAPH_API_URL}/test?param=value`,
                 expect.objectContaining({
                     method: 'GET',
                     headers: expect.objectContaining({
-                        'x-api-key': MOCK_API_KEY,
+                        'x-api-key': process.env.LANGCHAIN_API_KEY,
                     }),
                 })
             );
@@ -71,12 +68,12 @@ describe('API Route Handler', () => {
             await POST(req);
 
             expect(global.fetch).toHaveBeenCalledWith(
-                `${MOCK_API_URL}/test`,
+                `${process.env.LANGGRAPH_API_URL}/test`,
                 expect.objectContaining({
                     method: 'POST',
                     body: requestBody,
                     headers: expect.objectContaining({
-                        'x-api-key': MOCK_API_KEY,
+                        'x-api-key': process.env.LANGCHAIN_API_KEY,
                     }),
                 })
             );
@@ -115,7 +112,7 @@ describe('API Route Handler', () => {
             await GET(req);
 
             expect(global.fetch).toHaveBeenCalledWith(
-                `${MOCK_API_URL}/test?a=1&b=2`,
+                `${process.env.LANGGRAPH_API_URL}/test?a=1&b=2`,
                 expect.any(Object)
             );
         });


### PR DESCRIPTION
Fixes #90

Resolve code scanning alert for hard-coded credentials in test file.

* Remove hard-coded credentials `MOCK_API_KEY` and `MOCK_API_URL` from `__tests__/api/proxy.test.ts`.
* Load environment variables from `.env.test` file using `dotenv.config`.
* Update test cases to use `process.env.LANGCHAIN_API_KEY` and `process.env.LANGGRAPH_API_URL` instead of hard-coded values.
* Add `.env.test` file with mock credentials `LANGCHAIN_API_KEY=test-api-key` and `LANGGRAPH_API_URL=https://api.example.com`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/eddo-ai/teachers-assistant-web-client/pull/91?shareId=ec007084-2dcc-45a6-8c53-bf319d3678fc).