### PR TITLE
Implement agent function for authorization

### DIFF
--- a/__tests__/lib/chatApi.test.ts
+++ b/__tests__/lib/chatApi.test.ts
@@ -1,0 +1,92 @@
+import { authorize } from '@/lib/chatApi';
+import { tool_manager } from '@/lib/toolManager';
+
+jest.mock('@/lib/toolManager', () => ({
+  tool_manager: {
+    requires_auth: jest.fn(),
+    authorize: jest.fn(),
+    wait_for_auth: jest.fn(),
+    is_authorized: jest.fn(),
+  },
+}));
+
+describe('authorize', () => {
+  const mockState = {
+    messages: [
+      {
+        tool_calls: [
+          { name: 'tool1' },
+          { name: 'tool2' },
+        ],
+      },
+    ],
+  };
+
+  const mockConfig = {
+    configurable: new Map([['user_id', 'test_user_id']]),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should handle tools that do not require authorization', async () => {
+    tool_manager.requires_auth.mockReturnValue(false);
+
+    const result = await authorize(mockState, mockConfig);
+
+    expect(tool_manager.requires_auth).toHaveBeenCalledWith('tool1');
+    expect(tool_manager.requires_auth).toHaveBeenCalledWith('tool2');
+    expect(tool_manager.authorize).not.toHaveBeenCalled();
+    expect(result).toEqual({ messages: [] });
+  });
+
+  it('should handle tools that require authorization', async () => {
+    tool_manager.requires_auth.mockReturnValue(true);
+    tool_manager.authorize.mockReturnValue({ status: 'completed' });
+
+    const result = await authorize(mockState, mockConfig);
+
+    expect(tool_manager.requires_auth).toHaveBeenCalledWith('tool1');
+    expect(tool_manager.requires_auth).toHaveBeenCalledWith('tool2');
+    expect(tool_manager.authorize).toHaveBeenCalledWith('tool1', 'test_user_id');
+    expect(tool_manager.authorize).toHaveBeenCalledWith('tool2', 'test_user_id');
+    expect(result).toEqual({ messages: [] });
+  });
+
+  it('should prompt user for authorization if not completed', async () => {
+    tool_manager.requires_auth.mockReturnValue(true);
+    tool_manager.authorize.mockReturnValue({ status: 'pending', url: 'http://auth.url', id: 'auth_id' });
+    tool_manager.is_authorized.mockReturnValue(true);
+
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const result = await authorize(mockState, mockConfig);
+
+    expect(tool_manager.requires_auth).toHaveBeenCalledWith('tool1');
+    expect(tool_manager.requires_auth).toHaveBeenCalledWith('tool2');
+    expect(tool_manager.authorize).toHaveBeenCalledWith('tool1', 'test_user_id');
+    expect(tool_manager.authorize).toHaveBeenCalledWith('tool2', 'test_user_id');
+    expect(consoleSpy).toHaveBeenCalledWith('Visit the following URL to authorize: http://auth.url');
+    expect(tool_manager.wait_for_auth).toHaveBeenCalledWith('auth_id');
+    expect(tool_manager.is_authorized).toHaveBeenCalledWith('auth_id');
+    expect(result).toEqual({ messages: [] });
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should throw an error if authorization fails', async () => {
+    tool_manager.requires_auth.mockReturnValue(true);
+    tool_manager.authorize.mockReturnValue({ status: 'pending', url: 'http://auth.url', id: 'auth_id' });
+    tool_manager.is_authorized.mockReturnValue(false);
+
+    await expect(authorize(mockState, mockConfig)).rejects.toThrow('Authorization failed');
+
+    expect(tool_manager.requires_auth).toHaveBeenCalledWith('tool1');
+    expect(tool_manager.requires_auth).toHaveBeenCalledWith('tool2');
+    expect(tool_manager.authorize).toHaveBeenCalledWith('tool1', 'test_user_id');
+    expect(tool_manager.authorize).toHaveBeenCalledWith('tool2', 'test_user_id');
+    expect(tool_manager.wait_for_auth).toHaveBeenCalledWith('auth_id');
+    expect(tool_manager.is_authorized).toHaveBeenCalledWith('auth_id');
+  });
+});

--- a/lib/chatApi.ts
+++ b/lib/chatApi.ts
@@ -52,3 +52,22 @@ export const sendMessage = async (params: {
     }
   );
 };
+
+export const authorize = async (state: any, config: any) => {
+  const user_id = config["configurable"].get("user_id");
+  for (const tool_call of state["messages"][-1].tool_calls) {
+    const tool_name = tool_call["name"];
+    if (!tool_manager.requires_auth(tool_name)) {
+      continue;
+    }
+    const auth_response = tool_manager.authorize(tool_name, user_id);
+    if (auth_response.status !== "completed") {
+      console.log(`Visit the following URL to authorize: ${auth_response.url}`);
+      tool_manager.wait_for_auth(auth_response.id);
+      if (!tool_manager.is_authorized(auth_response.id)) {
+        throw new Error("Authorization failed");
+      }
+    }
+  }
+  return { messages: [] };
+};


### PR DESCRIPTION
Fixes #77

Add `authorize` function to handle tool-specific authorization.

* **lib/chatApi.ts**
  - Add `authorize` function to check if a tool requires authorization and prompt the user to visit the authorization URL if needed.
  - Wait for the user to complete the authorization and verify the authorization status.
  - Raise an error if authorization fails.

* **__tests__/lib/chatApi.test.ts**
  - Add unit tests for `authorize` function.
  - Test different tool authorization methods.
  - Handle tools that do not require authorization.
  - Handle tools that require authorization.
  - Prompt user for authorization if not completed.
  - Throw an error if authorization fails.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/eddo-ai/teachers-assistant-web-client/pull/92?shareId=c95025ed-fe17-4dac-bec2-910955cc03d1).