### PR TITLE
Add domain check

### DIFF
--- a/__tests__/api/auth.test.ts
+++ b/__tests__/api/auth.test.ts
@@ -91,4 +91,41 @@ describe('Auth Routes', () => {
             expect(data).toEqual({ user: null });
         });
     });
+
+    describe('Middleware Domain Check', () => {
+        it('should allow users with @eddolearning.com email domain and verified email', async () => {
+            const mockUser = {
+                sub: 'auth0|123',
+                name: 'Test User',
+                email: 'test@eddolearning.com',
+                email_verified: true
+            };
+
+            (getSession as jest.Mock).mockResolvedValue({ user: mockUser });
+
+            const request = mockRequest('protected');
+            const { middleware } = require('@/app/middleware');
+            const response = await middleware(request);
+
+            expect(response.status).toBe(200);
+        });
+
+        it('should redirect users with non-@eddolearning.com email domain or unverified email', async () => {
+            const mockUser = {
+                sub: 'auth0|123',
+                name: 'Test User',
+                email: 'test@example.com',
+                email_verified: false
+            };
+
+            (getSession as jest.Mock).mockResolvedValue({ user: mockUser });
+
+            const request = mockRequest('protected');
+            const { middleware } = require('@/app/middleware');
+            const response = await middleware(request);
+
+            expect(response.status).toBe(302);
+            expect(response.headers.get('Location')).toBe('/not-found');
+        });
+    });
 });

--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { getSession } from '@auth0/nextjs-auth0';
+
+export async function middleware(req) {
+  const session = await getSession(req, NextResponse.next());
+
+  if (!session || !session.user) {
+    return NextResponse.redirect('/api/auth/login');
+  }
+
+  const { email, email_verified } = session.user;
+
+  if (!email.endsWith('@eddolearning.com') || !email_verified) {
+    return NextResponse.redirect('/not-found');
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    '/protected/:path*',
+    '/api/protected/:path*',
+  ],
+};

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -8,6 +8,7 @@ export default function NotFound() {
             <h1 className="text-4xl font-bold mb-4">404</h1>
             <h2 className="text-xl mb-4">Page Not Found</h2>
             <p className="text-gray-600 mb-8">The page you're looking for doesn't exist or has been moved.</p>
+            <p className="text-gray-600 mb-8">Your email domain is not allowed or your email is not verified.</p>
             <Link
                 href="/"
                 className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-500 transition-colors"


### PR DESCRIPTION
Fixes #97

Add domain check middleware and update tests and error page.

* **Middleware**: Add `app/middleware.ts` to check user's email domain and verification status. Redirect users with non-`@eddolearning.com` email or unverified email to `/not-found`.
* **Tests**: Update `__tests__/api/auth.test.ts` to include test cases for the new middleware function, ensuring correct behavior for allowed and disallowed email domains.
* **Error Page**: Modify `app/not-found.tsx` to include a message informing users that their email domain is not allowed or their email is not verified.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/eddo-ai/teachers-assistant-web-client/pull/98?shareId=623caa29-6031-43ad-86d1-669964f4860f).