### PR TITLE
Fix 422 error from /stream endpoint

### DIFF
--- a/__tests__/api/proxy.test.ts
+++ b/__tests__/api/proxy.test.ts
@@ -111,6 +111,26 @@ describe('API Route Handler', () => {
                 })
             );
         });
+
+        it('should handle 422 status code from /runs/stream endpoint', async () => {
+            const mockResponse = new Response(JSON.stringify({ message: 'Unprocessable Entity' }), {
+                status: 422,
+                headers: new Headers({
+                    'Content-Type': 'application/json'
+                })
+            });
+            (global.fetch as jest.Mock).mockResolvedValueOnce(mockResponse);
+
+            const req = new NextRequest('http://localhost:3000/api/runs/stream', {
+                method: 'POST',
+                body: JSON.stringify({}),
+            });
+            const response = await POST(req);
+            const data = await response.json();
+
+            expect(response.status).toBe(422);
+            expect(data.error).toBe('Unprocessable Entity: The request was well-formed but was unable to be followed due to semantic errors.');
+        });
     });
 
     describe('Error Handling', () => {

--- a/lib/chatApi.ts
+++ b/lib/chatApi.ts
@@ -3,6 +3,7 @@ import {
   LangChainMessage,
   LangGraphCommand,
 } from "@assistant-ui/react-langgraph";
+import { getAccessToken } from '@auth0/nextjs-auth0/edge';
 
 const createClient = () => {
   const apiUrl =
@@ -32,23 +33,41 @@ export const sendMessage = async (params: {
   userId?: string | null;
 }) => {
   const client = createClient();
-  return client.runs.stream(
-    params.threadId,
-    process.env["NEXT_PUBLIC_LANGGRAPH_ASSISTANT_ID"]!,
-    {
-      input: params.messages?.length
-        ? {
-          messages: params.messages,
-        }
-        : null,
-      command: params.command,
-      streamMode: ["messages", "updates"],
-      config: {
-        configurable: {
-          user_id: params.userId,
-          thread_id: params.threadId,
+  const { accessToken } = await getAccessToken();
+  if (!accessToken) {
+    throw new Error('Invalid access token');
+  }
+
+  const headers = {
+    'X-Api-Key': process.env["NEXT_PUBLIC_LANGGRAPH_API_KEY"]!,
+    'Authorization': `Bearer ${accessToken}`
+  };
+
+  try {
+    return await client.runs.stream(
+      params.threadId,
+      process.env["NEXT_PUBLIC_LANGGRAPH_ASSISTANT_ID"]!,
+      {
+        input: params.messages?.length
+          ? {
+            messages: params.messages,
+          }
+          : null,
+        command: params.command,
+        streamMode: ["messages", "updates"],
+        config: {
+          configurable: {
+            user_id: params.userId,
+            thread_id: params.threadId,
+          },
         },
       },
+      { headers }
+    );
+  } catch (error) {
+    if (error.response && error.response.status === 422) {
+      throw new Error('Unprocessable Entity: The request was well-formed but was unable to be followed due to semantic errors.');
     }
-  );
+    throw error;
+  }
 };


### PR DESCRIPTION
Fixes #103

Add error handling for 422 status code in the `sendMessage` function in `lib/chatApi.ts`.

* **Error Handling**:
  - Add error handling for 422 status code in the `sendMessage` function.
  - Return a specific error message for 422 status code in the `sendMessage` function.
  - Verify that the `X-Api-Key` header is included in the request in the `sendMessage` function.
  - Confirm that the `getAccessToken` function returns a valid access token in the `sendMessage` function.

* **Testing**:
  - Add a test case for handling 422 status code from `/runs/stream` endpoint in the `POST` method in `__tests__/api/proxy.test.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/eddo-ai/teachers-assistant-web-client/pull/104?shareId=4899bfe0-1d44-4338-9afe-1aba696d6f19).