### PR TITLE
Add pull request check action to run pnpm tests

### DIFF
--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -1,0 +1,50 @@
+name: Pull Request Check
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'pnpm'
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Run Linting
+        run: pnpm run lint
+        continue-on-error: true
+
+      - name: Run Tests
+        id: test
+        run: pnpm run test:ci
+
+      - name: Build Next.js Application
+        id: build
+        run: pnpm run build
+
+      - name: Reject PR if Build/Test Fails
+        if: steps.test.outcome == 'failure' || steps.build.outcome == 'failure'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          gh api repos/${{ github.repository }}/issues/$PR_NUMBER/comments \
+            -f body="❌ Build or tests failed. Please check the logs and fix errors."
+          exit 1

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "test:ci": "pnpm jest --ci"
   },
   "dependencies": {
     "@assistant-ui/react": "^0.7.58",


### PR DESCRIPTION
Fixes #111

Add a new GitHub Action workflow to run `pnpm` tests on pull request events.

* **package.json**
  - Add `test:ci` script to run `jest` with `--ci` flag using `pnpm`.

* **.github/workflows/pull-request-check.yml**
  - Create a new workflow file to run `pnpm` tests on pull requests.
  - Trigger workflow on `pull_request` events including `opened`, `synchronize`, and `reopened`.
  - Include steps to checkout repository, set up Node.js, install `pnpm`, install dependencies, run linting, run tests, and build application.
  - Reject pull request if build or tests fail and comment on PR with failure message.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/eddo-ai/teachers-assistant-web-client/pull/112?shareId=ea9c3048-7a8e-45a9-aae6-5bd787c9e209).