### PR TITLE
Fix workflow permissions in GitHub Actions

### DIFF
--- a/.github/workflows/auto-assign-issue-creator.yml
+++ b/.github/workflows/auto-assign-issue-creator.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  security-events: write
+
 jobs:
   assign-creator:
     runs-on: ubuntu-latest

--- a/.github/workflows/azure-static-web-apps-lively-coast-0ae46e91e.yml
+++ b/.github/workflows/azure-static-web-apps-lively-coast-0ae46e91e.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build_and_deploy_job:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
@@ -75,5 +78,5 @@ jobs:
         id: closepullrequest
         uses: Azure/static-web-apps-deploy@v1
         with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_LIVELY_COAST_0AE46E91E }}
+          azure_static web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_LIVELY_COAST_0AE46E91E }}
           action: "close"

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   build-test:

--- a/.github/workflows/debug-azure-web-app.yml
+++ b/.github/workflows/debug-azure-web-app.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   debug-deploy:


### PR DESCRIPTION
Fixes #114

Add necessary permissions to GitHub workflows to fix code scanning alert.

* **.github/workflows/auto-assign-issue-creator.yml**
  - Add `permissions` section with `security-events: write`.

* **.github/workflows/azure-static-web-apps-lively-coast-0ae46e91e.yml**
  - Add `permissions` section with `contents: read`.

* **.github/workflows/build-pr.yml**
  - Add `security-events: write` permission to the `permissions` section.

* **.github/workflows/debug-azure-web-app.yml**
  - Add `security-events: write` permission to the `permissions` section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/eddo-ai/teachers-assistant-web-client/pull/115?shareId=d4451848-6714-41a9-95cc-c2a8df30e001).