### PR TITLE
Add authorization interrupt handling

### DIFF
--- a/__tests__/components/MyAssistant.test.tsx
+++ b/__tests__/components/MyAssistant.test.tsx
@@ -263,7 +263,7 @@ describe('MyAssistant', () => {
             const confirmButton = screen.getByText('Yes');
             fireEvent.click(confirmButton);
 
-            expect(sendCommandMock).toHaveBeenCalledWith({ resume: 'yes' });
+            expect(sendCommandMock).toHaveBeenCalledWith({ resume: 'yes', type: 'authorization' });
         });
 
         it('calls sendCommand with "no" when Reject button is clicked', () => {
@@ -278,7 +278,34 @@ describe('MyAssistant', () => {
             const rejectButton = screen.getByText('No');
             fireEvent.click(rejectButton);
 
-            expect(sendCommandMock).toHaveBeenCalledWith({ resume: 'no' });
+            expect(sendCommandMock).toHaveBeenCalledWith({ resume: 'no', type: 'authorization' });
+        });
+
+        it('renders OAuth interrupt UI when there is an OAuth interrupt', () => {
+            (useLangGraphInterruptState as jest.Mock).mockReturnValue({
+                value: 'Please use the following link to authorize: https://accounts.google.com/o/oauth2/auth',
+            });
+
+            render(<MyAssistant />);
+
+            expect(screen.getByText('Authorization Required')).toBeInTheDocument();
+            expect(screen.getByText('Please visit this URL to authorize access:')).toBeInTheDocument();
+            expect(screen.getByText('https://accounts.google.com/o/oauth2/auth')).toBeInTheDocument();
+        });
+
+        it('calls sendCommand with "no" when Cancel button is clicked in OAuth interrupt UI', () => {
+            const sendCommandMock = jest.fn();
+            (useLangGraphInterruptState as jest.Mock).mockReturnValue({
+                value: 'Please use the following link to authorize: https://accounts.google.com/o/oauth2/auth',
+            });
+            (useLangGraphSendCommand as jest.Mock).mockReturnValue(sendCommandMock);
+
+            render(<MyAssistant />);
+
+            const cancelButton = screen.getByText('Cancel');
+            fireEvent.click(cancelButton);
+
+            expect(sendCommandMock).toHaveBeenCalledWith({ resume: 'no', type: 'authorization' });
         });
     });
 });

--- a/components/MyAssistant.tsx
+++ b/components/MyAssistant.tsx
@@ -35,10 +35,10 @@ const InterruptUI = () => {
       <div className="flex flex-col gap-2 p-4 border rounded-lg bg-gray-50">
         <div className="text-lg font-medium">Interrupt: {interrupt.value}</div>
         <div className="flex items-end gap-2">
-          <Button onClick={() => sendCommand({ resume: "yes" })} variant="default">
+          <Button onClick={() => sendCommand({ resume: "yes", type: "authorization" })} variant="default">
             Yes
           </Button>
-          <Button onClick={() => sendCommand({ resume: "no" })} variant="outline">
+          <Button onClick={() => sendCommand({ resume: "no", type: "authorization" })} variant="outline">
             No
           </Button>
         </div>
@@ -66,7 +66,7 @@ const InterruptUI = () => {
           Open URL
         </Button>
         <Button
-          onClick={() => sendCommand({ resume: 'no' })}
+          onClick={() => sendCommand({ resume: 'no', type: 'authorization' })}
           variant="outline"
         >
           Cancel


### PR DESCRIPTION
Fixes #185

Update `MyAssistant.tsx` to include a type for identification in authorization requests.

* **InterruptUI Component**
  - Update `InterruptUI` component to include a type for identification in authorization requests.
  - Use `useLangGraphSendCommand` hook to send a command with the type for identification when the user chooses an option.

* **Tests**
  - Add test cases to verify that the `InterruptUI` component includes a type for identification in authorization requests.
  - Add test cases to verify that the `useLangGraphSendCommand` hook sends a command with the type for identification when the user chooses an option.
  - Add test cases to verify that the `InterruptUI` component handles OAuth interrupts and sends an interrupt with a type for identification.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/eddo-ai/teachers-assistant-web-client/issues/185?shareId=XXXX-XXXX-XXXX-XXXX).