### PR TITLE
Update Dockerfile to build and start Next.js application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /usr/src/app
 COPY ["package.json", "package-lock.json*", "npm-shrinkwrap.json*", "./"]
 RUN npm install --production --silent && mv node_modules ../
 COPY . .
+RUN npm run build
 EXPOSE 3000
 RUN chown -R node /usr/src/app
 USER node


### PR DESCRIPTION
Fixes #189

Update `Dockerfile` to build and start Next.js application

* Add a build step using `npm run build` before starting the application with `npm start`
* Ensure the `Dockerfile` builds and starts the Next.js application correctly

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/eddo-ai/teachers-assistant-web-client/pull/190?shareId=9841b510-e8d1-481c-a305-30ea58786320).